### PR TITLE
fix: update grpc-js package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.9.2",
+        "@grpc/grpc-js": "^1.9.7",
         "@grpc/proto-loader": "^0.6.13",
         "ajv": "^8.12.0",
         "axios": "^1.3.5",
@@ -1325,9 +1325,9 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.2.tgz",
-      "integrity": "sha512-Lf2pUhNTaviEdEaGgjU+29qw3arX7Qd/45q66F3z1EV5hroE6wM9xSHPvjB8EY+b1RmKZgwnLWXQorC6fZ9g5g==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.7.tgz",
+      "integrity": "sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -9973,9 +9973,9 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.2.tgz",
-      "integrity": "sha512-Lf2pUhNTaviEdEaGgjU+29qw3arX7Qd/45q66F3z1EV5hroE6wM9xSHPvjB8EY+b1RmKZgwnLWXQorC6fZ9g5g==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.7.tgz",
+      "integrity": "sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==",
       "requires": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-integration-no-server": "jest --colors --config=jest.config-integration.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.9.2",
+    "@grpc/grpc-js": "^1.9.7",
     "@grpc/proto-loader": "^0.6.13",
     "ajv": "^8.12.0",
     "axios": "^1.3.5",


### PR DESCRIPTION
This update fixes a few of our problems.
1. [version 1.9.6](https://github.com/grpc/grpc-node/pull/2598) provides an extended error info. This helps in case of a wrong certificate 
2. [version 1.9.7](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.9.7) fixes updating name resolution. Probably, we can get rid of grpcRecreateService option.