### PR TITLE
feat: add ability to set responseType in ApiServiceRestActionConfig

### DIFF
--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -288,6 +288,12 @@ export default function createRestAction<Context extends GatewayContext>(
             });
         }
 
+        if (config.responseType) {
+            Object.assign(requestConfig, {
+                responseType: config.responseType,
+            });
+        }
+
         try {
             const response = await axiosClient.request(requestConfig);
 

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -170,6 +170,7 @@ export interface ApiServiceRestActionConfig<
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
     path: (args: TParams) => string;
     paramsSerializer?: AxiosRequestConfig['paramsSerializer'];
+    responseType?: AxiosRequestConfig['responseType'];
     maxRedirects?: number;
 }
 


### PR DESCRIPTION
Add ability to set `responseType` in `ApiServiceRestActionConfig` for rest actions