### PR TITLE
fix: reduce reflection connection errors

### DIFF
--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -463,6 +463,9 @@ function getServiceInstanceReflectCached(
 
     const service = getServiceInstanceReflect(config, endpointData, grpcOptions, credentials);
     _.set(reflectionServiceInstancesMap, cacheKey, service);
+    service.catch(() => {
+        _.set(reflectionServiceInstancesMap, cacheKey, undefined);
+    });
     return service;
 }
 

--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -422,18 +422,29 @@ async function refreshCache(
         isRefresh: true,
     });
 
-    const res = await getServiceInstanceReflect(
-        config,
-        endpointData,
-        grpcOptions,
-        credentials,
-        true,
-    );
-    _.set(reflectionServiceInstancesMap, [config.protoKey, actionEndpoint], Promise.resolve(res));
-    _.set(reflectionCacheStatusMap, [config.protoKey, actionEndpoint], {
-        time: Date.now() / 1000,
-        isRefresh: false,
-    });
+    try {
+        const res = await getServiceInstanceReflect(
+            config,
+            endpointData,
+            grpcOptions,
+            credentials,
+            true,
+        );
+        _.set(
+            reflectionServiceInstancesMap,
+            [config.protoKey, actionEndpoint],
+            Promise.resolve(res),
+        );
+        _.set(reflectionCacheStatusMap, [config.protoKey, actionEndpoint], {
+            time: Date.now() / 1000,
+            isRefresh: false,
+        });
+    } catch (e) {
+        _.set(reflectionCacheStatusMap, [config.protoKey, actionEndpoint], {
+            ...cacheStatus,
+            isRefresh: false,
+        });
+    }
 }
 
 function getServiceInstanceReflectCached(

--- a/lib/utils/grpc-reflection.ts
+++ b/lib/utils/grpc-reflection.ts
@@ -18,6 +18,7 @@ type DescriptorExtensionProto =
 function getCachedClient(
     actionEndpoint: string,
     credentials: ChannelCredentials,
+    grpcOptions?: object,
     descriptorExtensionProto?: DescriptorExtensionProto,
 ) {
     let client = reflectionClientsMap[actionEndpoint];
@@ -38,7 +39,7 @@ function getCachedClient(
         client = new grpcReflection.Client(
             actionEndpoint,
             credentials,
-            undefined,
+            grpcOptions,
             undefined,
             descriptorRoot,
         );
@@ -52,6 +53,7 @@ function getCachedClient(
  * @param actionEndpoint
  * @param protoKey
  * @param credentials
+ * @param grpcOptions
  * @param descriptorExtensionProto
  * @returns Promise<protobufjs.Root>.
  * use toDescriptor for use with protoLoader.
@@ -61,9 +63,15 @@ export async function getCachedReflectionRoot(
     actionEndpoint: string,
     protoKey: string,
     credentials: ChannelCredentials,
+    grpcOptions?: object,
     descriptorExtensionProto?: DescriptorExtensionProto,
 ) {
-    const client = getCachedClient(actionEndpoint, credentials, descriptorExtensionProto);
+    const client = getCachedClient(
+        actionEndpoint,
+        credentials,
+        grpcOptions,
+        descriptorExtensionProto,
+    );
 
     let cachedRootPromise = _.get(reflectionRootPromiseMap, [actionEndpoint, protoKey]);
     if (!cachedRootPromise) {
@@ -78,6 +86,7 @@ export async function getCachedReflectionRoot(
  * @param actionEndpoint
  * @param protoKey
  * @param credentials
+ * @param grpcOptions
  * @param addToCache
  * @returns Promise<protobufjs.Root>.
  * use toDescriptor for use with protoLoader.
@@ -87,9 +96,10 @@ export async function getReflectionRoot(
     actionEndpoint: string,
     protoKey: string,
     credentials: ChannelCredentials,
+    grpcOptions?: object,
     addToCache?: boolean,
 ) {
-    const client = getCachedClient(actionEndpoint, credentials);
+    const client = getCachedClient(actionEndpoint, credentials, grpcOptions);
     const loadedRoot = await client.fileContainingSymbol(protoKey);
     if (addToCache) {
         _.set(reflectionRootPromiseMap, [actionEndpoint, protoKey], Promise.resolve(loadedRoot));

--- a/lib/utils/grpc-reflection.ts
+++ b/lib/utils/grpc-reflection.ts
@@ -85,6 +85,9 @@ export async function getCachedReflectionRoot(
     if (!cachedRootPromise) {
         cachedRootPromise = client.fileContainingSymbol(protoKey);
         _.set(reflectionRootPromiseMap, [actionEndpoint, protoKey], cachedRootPromise);
+        cachedRootPromise.catch(() => {
+            _.set(reflectionRootPromiseMap, [actionEndpoint, protoKey], undefined);
+        });
     }
     const loadedRoot = await cachedRootPromise;
     return loadedRoot;


### PR DESCRIPTION
In this PR:
- use the same GRPC options in reflection client as in corresponding actions
- fix problems with cached reflection clients
- remove failed reflection requests from cache
- fix uncaught promise exception during cache refresh