### PR TITLE
fix!: change default value for encodePathArgs option

### DIFF
--- a/lib/utils/validate.ts
+++ b/lib/utils/validate.ts
@@ -33,6 +33,8 @@ export function getPathArgsProxy<TParams extends {}>(
     args: TParams,
     encodePathArgs?: boolean,
 ): TParams {
+    const encodePathArgsVal = encodePathArgs ?? true;
+
     if (!args) {
         return args;
     }
@@ -51,7 +53,7 @@ export function getPathArgsProxy<TParams extends {}>(
 
             if (typeof value === 'string') {
                 const pathParam = getPathParam(value);
-                return encodePathArgs ? encodeURIComponent(pathParam) : pathParam;
+                return encodePathArgsVal ? encodeURIComponent(pathParam) : pathParam;
             }
 
             return value; // TODO return error INVALID_PARAMS


### PR DESCRIPTION
Set option `encodePathArgs` to true by default