### PR TITLE
fix!: move originalError to debug field

### DIFF
--- a/lib/utils/parse-error.ts
+++ b/lib/utils/parse-error.ts
@@ -16,10 +16,8 @@ export function parseMixedError(e: Error & {code?: string}) {
         status: 500,
         message: String(e.message || DEFAULT_GATEWAY_MESSAGE),
         code: String(e.code || DEFAULT_GATEWAY_CODE),
-        details: {
-            originalError: e,
-        },
         debug: {
+            originalError: e,
             stack: e.stack,
         },
     };


### PR DESCRIPTION
Move `originalError` to debug section in error returned from parseMixedError function.  This section will be omitted if there is no `withDebugHeaders` option in gateway config