### PR TITLE
feat: add ability to return response headers

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -330,6 +330,7 @@ describe('getGatewayControllers', () => {
             const res: any = {
                 status: jest.fn((_) => res),
                 send: jest.fn(),
+                set: jest.fn(),
             };
             await controller(req, res);
             expect(res.status.mock.calls[0][0]).toBe(404);
@@ -365,6 +366,7 @@ describe('getGatewayControllers', () => {
             const res: any = {
                 status: jest.fn((_) => res),
                 send: jest.fn(),
+                set: jest.fn(),
             };
 
             await controller(
@@ -393,6 +395,7 @@ describe('getGatewayControllers', () => {
             const res: any = {
                 status: jest.fn((_) => res),
                 send: jest.fn(),
+                set: jest.fn(),
             };
 
             await controller(
@@ -449,6 +452,7 @@ describe('getGatewayControllers', () => {
             const res: any = {
                 status: jest.fn((_) => res),
                 send: jest.fn(),
+                set: jest.fn(),
             };
 
             await controller1(
@@ -746,6 +750,7 @@ describe('getGatewayControllers', () => {
             const res: any = {
                 status: jest.fn((_) => res),
                 send: jest.fn(),
+                set: jest.fn(),
                 locals: {
                     token: '777',
                 },

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -288,7 +288,7 @@ function generateGatewayApiController<
                 res.set(debugHeaders);
             }
 
-            if (responseHeaders && Object.keys(responseHeaders).length) {
+            if (responseHeaders) {
                 res.set(responseHeaders);
             }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -288,7 +288,7 @@ function generateGatewayApiController<
                 res.set(debugHeaders);
             }
 
-            if (responseHeaders) {
+            if (responseHeaders && Object.keys(responseHeaders).length) {
                 res.set(responseHeaders);
             }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -276,7 +276,7 @@ function generateGatewayApiController<
                 }
             }
 
-            const {responseData, debugHeaders} = await apiAction({
+            const {responseData, responseHeaders, debugHeaders} = await apiAction({
                 requestId: req.id,
                 headers: req.headers,
                 ctx: req.ctx,
@@ -286,6 +286,10 @@ function generateGatewayApiController<
 
             if (withDebugHeaders) {
                 res.set(debugHeaders);
+            }
+
+            if (responseHeaders) {
+                res.set(responseHeaders);
             }
 
             if (onRequestSuccess) {

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -86,6 +86,9 @@ export type ProxyHeadersFunction = (
 ) => IncomingHttpHeaders;
 export type ProxyHeaders = string[] | ProxyHeadersFunction;
 
+export type ProxyResponseHeadersFunction = (headers: Headers, type: ControllerType) => Headers;
+export type ProxyResponseHeaders = string[] | ProxyResponseHeadersFunction;
+
 export type GetAuthHeadersParams<AuthArgs = Record<string, unknown>> = {
     actionType: 'rest' | 'grpc';
     serviceName: string;
@@ -158,6 +161,7 @@ export interface ApiServiceBaseActionConfig<
     retries?: number;
     idempotency?: boolean;
     proxyHeaders?: ProxyHeaders;
+    proxyResponseHeaders?: ProxyResponseHeaders;
     metadata?: Record<string, string | number | boolean>;
 }
 
@@ -321,6 +325,7 @@ export interface GatewayActionHeaders {
 
 export interface GatewayActionUnaryResponse<TAction> extends GatewayActionHeaders {
     responseData: ApiActionResponseType<TAction>;
+    responseHeaders?: Headers;
 }
 
 export interface GatewayActionClientStreamResponse<TAction> extends GatewayActionHeaders {

--- a/lib/utils/common.ts
+++ b/lib/utils/common.ts
@@ -44,11 +44,12 @@ export function sanitizeDebugHeaders(debugHeaders: Headers) {
     return _.omit(debugHeaders, ['x-api-request-body']);
 }
 
-export function getHeadersFromMetadata(metadata: Record<string, grpc.MetadataValue[]>) {
+export function getHeadersFromMetadata(
+    metadata: Record<string, grpc.MetadataValue[]>,
+    prefix = '',
+) {
     return Object.entries(metadata).reduce((headers, [key, values]) => {
-        headers[`x-metadata-${key}`] = values
-            .filter((value) => typeof value === 'string')
-            .join(' ');
+        headers[`${prefix}${key}`] = values.filter((value) => typeof value === 'string').join(' ');
         return headers;
     }, {} as Record<string, string>);
 }


### PR DESCRIPTION
add ability to return response headers option via `proxyResponseHeaders` option in action config