### PR TITLE
feat: add ability to validate response content type in rest actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ interface GatewayConfig {
   // Validation schema for parameters used when no schema is present in the action. Documentation: https://ajv.js.org/json-schema.html#json-data-type
   // You can use DEFAULT_VALIDATION_SCHEMA from lib/constants.ts.
   validationSchema?: object;
-  // Enables encoding of REST path arguments.
+  // Enables encoding of REST path arguments (default is true).
   encodePathArgs?: boolean;
   // Configuration for automatic connection re-establishment upon connection error through L3 load balancer (default is true).
   grpcRecreateService?: boolean;
+  // Enable verification of response contentType header. Actual only for REST actions. This value can be set / redefined the in action confg.
+  expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
 }
 ```
 

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -110,6 +110,7 @@ export interface GatewayApiOptions<Context extends GatewayContext> {
     proxyHeaders?: ProxyHeaders;
     validationSchema?: object;
     encodePathArgs?: boolean;
+    expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
     getAuthHeaders: GetAuthHeaders;
 }
 
@@ -175,6 +176,7 @@ export interface ApiServiceRestActionConfig<
     path: (args: TParams) => string;
     paramsSerializer?: AxiosRequestConfig['paramsSerializer'];
     responseType?: AxiosRequestConfig['responseType'];
+    expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
     maxRedirects?: number;
 }
 


### PR DESCRIPTION
Add ability to validate response content type in rest actions via option `expectedResponseContentType` in gateway config or action config. If this option is presented in configuration gateway will return `INVALID_RESPONSE_CONTENT_TYPE` error in case of mismatch.

Close https://github.com/gravity-ui/rfc/issues/6