### PR TITLE
feat: add ability to specify an array in expectedResponseContentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ type ProxyHeadersFunction = (
   type: ControllerType,
 ) => IncomingHttpHeaders;
 type ProxyHeaders = string[] | ProxyHeadersFunction;
+type ResponseContentType = AxiosResponse['headers']['Content-Type'];
 
 interface GatewayConfig {
   // Gateway Installation (external/internal/...). If the configuration is not provided, it is determined from process.env.APP_INSTALLATION.
@@ -119,7 +120,7 @@ interface GatewayConfig {
   // Configuration for automatic connection re-establishment upon connection error through L3 load balancer (default is true).
   grpcRecreateService?: boolean;
   // Enable verification of response contentType header. Actual only for REST actions. This value can be set / redefined the in action confg.
-  expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
+  expectedResponseContentType?: ResponseContentType | ResponseContentType[];
 }
 ```
 

--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -305,29 +305,38 @@ export default function createRestAction<Context extends GatewayContext>(
             const expectedResponseContentType =
                 config.expectedResponseContentType || options.expectedResponseContentType;
 
-            if (
-                actualResponseContentType &&
-                expectedResponseContentType &&
-                actualResponseContentType !== expectedResponseContentType
-            ) {
-                ctx.log('Invalid response content type', {
-                    expectedResponseContentType,
-                    actualResponseContentType,
-                });
-                ctx.end();
+            if (actualResponseContentType && expectedResponseContentType) {
+                let invalidResponseContentType;
 
-                return Promise.reject({
-                    error: {
-                        status: 415,
-                        message: 'Response content type validation failed',
-                        code: 'INVALID_RESPONSE_CONTENT_TYPE',
-                        details: {
-                            title: 'Invalid response content type',
-                            description: `Expected to get ${expectedResponseContentType} but got ${actualResponseContentType}`,
+                if (Array.isArray(expectedResponseContentType)) {
+                    invalidResponseContentType = !expectedResponseContentType.includes(
+                        String(actualResponseContentType),
+                    );
+                } else {
+                    invalidResponseContentType =
+                        expectedResponseContentType !== actualResponseContentType;
+                }
+
+                if (invalidResponseContentType) {
+                    ctx.log('Invalid response content type', {
+                        expectedResponseContentType,
+                        actualResponseContentType,
+                    });
+                    ctx.end();
+
+                    return Promise.reject({
+                        error: {
+                            status: 415,
+                            message: 'Response content type validation failed',
+                            code: 'INVALID_RESPONSE_CONTENT_TYPE',
+                            details: {
+                                title: 'Invalid response content type',
+                                description: `Expected to get ${expectedResponseContentType} but got ${actualResponseContentType}`,
+                            },
                         },
-                    },
-                    debugHeaders,
-                });
+                        debugHeaders,
+                    });
+                }
             }
 
             if (config.transformResponseData) {

--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -306,18 +306,18 @@ export default function createRestAction<Context extends GatewayContext>(
                 config.expectedResponseContentType || options.expectedResponseContentType;
 
             if (actualResponseContentType && expectedResponseContentType) {
-                let invalidResponseContentType;
+                let isInvalidResponseContentType;
 
                 if (Array.isArray(expectedResponseContentType)) {
-                    invalidResponseContentType = !expectedResponseContentType.includes(
+                    isInvalidResponseContentType = !expectedResponseContentType.includes(
                         String(actualResponseContentType),
                     );
                 } else {
-                    invalidResponseContentType =
+                    isInvalidResponseContentType =
                         expectedResponseContentType !== actualResponseContentType;
                 }
 
-                if (invalidResponseContentType) {
+                if (isInvalidResponseContentType) {
                     ctx.log('Invalid response content type', {
                         expectedResponseContentType,
                         actualResponseContentType,

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -100,6 +100,8 @@ export type GetAuthHeaders<AuthArgs = Record<string, unknown>> = (
     params: GetAuthHeadersParams<AuthArgs>,
 ) => Record<string, string> | undefined;
 
+export type ResponseContentType = AxiosResponse['headers']['Content-Type'];
+
 export interface GatewayApiOptions<Context extends GatewayContext> {
     serviceName: string;
     timeout?: number;
@@ -110,7 +112,7 @@ export interface GatewayApiOptions<Context extends GatewayContext> {
     proxyHeaders?: ProxyHeaders;
     validationSchema?: object;
     encodePathArgs?: boolean;
-    expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
+    expectedResponseContentType?: ResponseContentType | ResponseContentType[];
     getAuthHeaders: GetAuthHeaders;
 }
 
@@ -176,7 +178,7 @@ export interface ApiServiceRestActionConfig<
     path: (args: TParams) => string;
     paramsSerializer?: AxiosRequestConfig['paramsSerializer'];
     responseType?: AxiosRequestConfig['responseType'];
-    expectedResponseContentType?: AxiosResponse['headers']['Content-Type'];
+    expectedResponseContentType?: ResponseContentType | ResponseContentType[];
     maxRedirects?: number;
 }
 


### PR DESCRIPTION
Add the ability to specify an array in `expectedResponseContentType` option