### PR TITLE
feat: added ability to specify headers for timeout and retries count

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -83,3 +83,5 @@ export const DEFAULT_VALIDATION_SCHEMA = {
         ],
     },
 };
+
+export const AXIOS_RETRY_NAMESPACE = 'axios-retry';

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -181,6 +181,8 @@ export interface ApiServiceRestActionConfig<
     responseType?: AxiosRequestConfig['responseType'];
     expectedResponseContentType?: ResponseContentType | ResponseContentType[];
     maxRedirects?: number;
+    timeoutHeader?: string;
+    retryHeader?: string;
 }
 
 export interface ApiServiceBaseGrpcActionConfig<


### PR DESCRIPTION
You can add for your action config `timeoutHeader` and `retryHeader` and get these headers in request

`timeoutHeader` is for time in ms for timeout

`retryHeader` is for current retry attempt

```js
const actions = {
    getHello: {
        method: 'GET',
        path: () => '/',
        timeoutHeader: 'x-request-timeout',
        retryHeader: 'x-request-attempt',
        retries: 3,
    },
}
```