### PR TITLE
chore(ApiActionConfig): locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ interface ApiActionConfig<Context, TRequestData> {
   timeout?: number;
   callback?: (response: TResponseData) => void;
   authArgs?: Record<string, unknown>;
+  locals?: Locals;
 }
 ```
 

--- a/lib/components/mixed.ts
+++ b/lib/components/mixed.ts
@@ -46,6 +46,7 @@ export function createMixedAction<
                 headers: actionConfig.headers,
                 lang: actionConfig.headers[DEFAULT_LANG_HEADER] || Lang.Ru,
                 ctx,
+                locals: actionConfig.locals,
                 ...extra,
             });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -284,6 +284,7 @@ function generateGatewayApiController<
                 ctx: req.ctx,
                 args,
                 authArgs: config.getAuthArgs(req, res),
+                locals: res.locals,
             });
 
             if (withDebugHeaders) {

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -3,7 +3,7 @@ import {IncomingHttpHeaders} from 'http';
 import {ClientDuplexStream, ClientReadableStream, ClientWritableStream} from '@grpc/grpc-js';
 import {HandlerType} from '@grpc/grpc-js/build/src/server-call';
 import {AxiosRequestConfig, AxiosResponse} from 'axios';
-import type {Request, Response} from 'express';
+import type {Locals, Request, Response} from 'express';
 
 import type {GrpcContext} from '../components/grpc';
 import {Lang} from '../constants';
@@ -40,6 +40,7 @@ export interface ApiActionConfig<
     timeout?: number;
     callback?: (response: TResponseData) => void;
     authArgs?: Record<string, unknown>;
+    locals?: Locals;
 }
 
 export interface GRPCActionData {
@@ -240,6 +241,7 @@ export interface ApiServiceMixedExtra<
     ctx: Context;
     config: GatewayConfig<Context, Req, Res>;
     grpcContext: GrpcContext;
+    locals?: Locals;
 }
 
 export type ApiServiceMixedActionConfig<


### PR DESCRIPTION
Motivation: I need `locals` from my `afterAuth` middlewares. 

May be it is breaking changes and potentially locals may be leaked into the client side and better write like this:

```
ApiServiceMixedExtra {
...
getLocals?: () => Locals
}
```

or `ApiServiceMixedExtra` is private for client side and 

```
{
...
locals?: Locals
}
```

is okey ???