### PR TITLE
fix: param error is returned more explicitly instead of an empty value

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ interface GatewayConfig {
 #### validationSchema
 
 By default, for path params in rest actions used the following regexp: `/^((?!(\.\.|\?|#|\\|\/)).)*$/i`.
-If the parameter value does not pass validation, the `INVALID_PARAM_VALUE` value is returned.
+If the parameter value does not pass validation, the `GATEWAY_INVALID_PARAM_VALUE` value is returned.
 
 ### Usage in Node.js
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ interface GatewayConfig {
 }
 ```
 
+#### validationSchema
+
+By default, for path params in rest actions used the following regexp: `/^((?!(\.\.|\?|#|\\|\/)).)*$/i`.
+If the parameter value does not pass validation, the `INVALID_PARAM_VALUE` value is returned.
+
 ### Usage in Node.js
 
 Upon gateway initialization, in addition to exporting the controller, it also exports an `api` object, which represents the core for executing requests to the backend.

--- a/lib/utils/validate.test.ts
+++ b/lib/utils/validate.test.ts
@@ -21,13 +21,13 @@ describe('validate: getPathArgsProxy', () => {
 
         expect(pathArgsProxy.fieldA).toBe(123);
         expect(pathArgsProxy.fieldB).toBe('abc');
-        expect(pathArgsProxy.fieldC).toBe('');
+        expect(pathArgsProxy.fieldC).toBe('INVALID_PARAM_VALUE');
         expect(pathArgsProxy.fieldD.fieldE).toBe(2);
         expect(pathArgsProxy.fieldD.fieldF).toBe('long-long_field');
         expect(pathArgsProxy.fieldD.fieldG[0].arrField).toBe(123);
         expect(pathArgsProxy.fieldD.fieldG[1].arrField).toBe(null);
-        expect(pathArgsProxy.fieldD.fieldG[2].arrField).toBe('');
-        expect(pathArgsProxy.fieldD.fieldH).toBe('');
+        expect(pathArgsProxy.fieldD.fieldG[2].arrField).toBe('INVALID_PARAM_VALUE');
+        expect(pathArgsProxy.fieldD.fieldH).toBe('INVALID_PARAM_VALUE');
         expect(pathArgsProxy.fieldD.fieldI).toBe(true);
         expect(pathArgsProxy.fieldJ).toBe(false);
         expect(pathArgsProxy.fieldK[0]).toBe('a');

--- a/lib/utils/validate.test.ts
+++ b/lib/utils/validate.test.ts
@@ -21,13 +21,13 @@ describe('validate: getPathArgsProxy', () => {
 
         expect(pathArgsProxy.fieldA).toBe(123);
         expect(pathArgsProxy.fieldB).toBe('abc');
-        expect(pathArgsProxy.fieldC).toBe('INVALID_PARAM_VALUE');
+        expect(pathArgsProxy.fieldC).toBe('GATEWAY_INVALID_PARAM_VALUE');
         expect(pathArgsProxy.fieldD.fieldE).toBe(2);
         expect(pathArgsProxy.fieldD.fieldF).toBe('long-long_field');
         expect(pathArgsProxy.fieldD.fieldG[0].arrField).toBe(123);
         expect(pathArgsProxy.fieldD.fieldG[1].arrField).toBe(null);
-        expect(pathArgsProxy.fieldD.fieldG[2].arrField).toBe('INVALID_PARAM_VALUE');
-        expect(pathArgsProxy.fieldD.fieldH).toBe('INVALID_PARAM_VALUE');
+        expect(pathArgsProxy.fieldD.fieldG[2].arrField).toBe('GATEWAY_INVALID_PARAM_VALUE');
+        expect(pathArgsProxy.fieldD.fieldH).toBe('GATEWAY_INVALID_PARAM_VALUE');
         expect(pathArgsProxy.fieldD.fieldI).toBe(true);
         expect(pathArgsProxy.fieldJ).toBe(false);
         expect(pathArgsProxy.fieldK[0]).toBe('a');

--- a/lib/utils/validate.ts
+++ b/lib/utils/validate.ts
@@ -26,7 +26,7 @@ export function encodePathParams<TParams extends {}>(params: TParams) {
 }
 
 export function getPathParam(value: string) {
-    return /^((?!(\.\.|\?|#|\\|\/)).)*$/i.test(value) ? value : '';
+    return /^((?!(\.\.|\?|#|\\|\/)).)*$/i.test(value) ? value : 'INVALID_PARAM_VALUE';
 }
 
 export function getPathArgsProxy<TParams extends {}>(

--- a/lib/utils/validate.ts
+++ b/lib/utils/validate.ts
@@ -26,7 +26,7 @@ export function encodePathParams<TParams extends {}>(params: TParams) {
 }
 
 export function getPathParam(value: string) {
-    return /^((?!(\.\.|\?|#|\\|\/)).)*$/i.test(value) ? value : 'INVALID_PARAM_VALUE';
+    return /^((?!(\.\.|\?|#|\\|\/)).)*$/i.test(value) ? value : 'GATEWAY_INVALID_PARAM_VALUE';
 }
 
 export function getPathArgsProxy<TParams extends {}>(


### PR DESCRIPTION
Param error is returned more explicitly instead of an empty value