### PR TITLE
fix: use onRetry function instead of interceptors for setting x-request-attempt header

### DIFF
--- a/lib/utils/axios.ts
+++ b/lib/utils/axios.ts
@@ -1,5 +1,6 @@
 import axios, {AxiosRequestConfig} from 'axios';
 import axiosRetry from 'axios-retry';
+import _ from 'lodash';
 
 import {DEFAULT_AXIOS_OPTIONS, DEFAULT_TIMEOUT} from '../constants';
 
@@ -19,6 +20,9 @@ export function getAxiosClient(
             }
 
             return axiosRetry.isNetworkError(error) || axiosRetry.isRetryableError(error);
+        },
+        onRetry: (retryCount, error, requestConfig) => {
+            _.set(requestConfig, ['headers', 'x-request-attempt'], retryCount || 0);
         },
     });
 


### PR DESCRIPTION
use `onRetry` function instead of interceptors for setting `x-request-attempt` header