### PR TITLE
fix: typing for traceId for compatible with nodekit context

### DIFF
--- a/lib/models/context.ts
+++ b/lib/models/context.ts
@@ -17,5 +17,5 @@ export interface GatewayContext {
         redactSensitiveKeys?: (headers: Dict) => Dict;
     };
     getMetadata: () => IncomingHttpHeaders;
-    getTraceId?: () => string;
+    getTraceId?: () => string | undefined;
 }


### PR DESCRIPTION
Incompatible with nodekit type
https://github.com/gravity-ui/nodekit/blob/main/src/lib/context.ts#L236