### PR TITLE
feat: export isRetryableError function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,6 +23,7 @@ import overrideEndpoints from './utils/overrideEndpoints';
 
 export * from './utils/typed-api';
 export * from './utils/grpc-reflection';
+export {isRetryableError as isRetryableGrpcError} from './utils/grpc';
 export * from './models/common';
 export * from './models/context';
 export * from './models/error';


### PR DESCRIPTION
As promised in https://github.com/gravity-ui/gateway/pull/107#discussion_r1952219070, added export for isRetryableError to use when writing custom retries conditions.