### PR TITLE
feat: add custom axios-retry-condition for rest configuration

### DIFF
--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -74,7 +74,7 @@ export default function createRestAction<Context extends GatewayContext>(
     const defaultAxiosClient = getAxiosClient(
         timeout,
         config?.retries,
-        options?.axiosRetryCondition,
+        config?.axiosRetryCondition ?? options?.axiosRetryCondition,
         options?.axiosConfig,
         options?.axiosInterceptors,
     );

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -202,6 +202,7 @@ export interface ApiServiceRestActionConfig<
     responseType?: AxiosRequestConfig['responseType'];
     expectedResponseContentType?: ResponseContentType | ResponseContentType[];
     maxRedirects?: number;
+    axiosRetryCondition?: AxiosRetryCondition;
 }
 
 export interface ApiServiceBaseGrpcActionConfig<


### PR DESCRIPTION
This PR adds support for custom axios retry conditions when define a REST actions

## Summary by Sourcery

Add support for custom axios retry conditions in REST configuration

New Features:
- Extend REST configuration to allow specifying custom axios retry conditions at both service and action levels

Enhancements:
- Modify REST action creation to prioritize configuration-level retry conditions over default options