### PR TITLE
chore: update ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: 20
           cache: 'npm'
       - name: Install Packages
         run: npm ci
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: 20
           cache: 'npm'
       - name: Install Packages
         run: npm ci
@@ -50,13 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: 20
           cache: 'npm'
       - name: Install Packages
         run: npm ci

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - name: Install Packages
         run: npm ci

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
           npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
-          node-version: 18
+          node-version: 20
           default-branch: ${{ github.event.inputs.branch }}
           npm-dist-tag: untagged
           npm-preid: alpha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
           npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
-          node-version: 18
+          node-version: 20
           default-branch: ${{ github.ref_name != 'main' && github.ref_name || null }}
           npm-dist-tag: ${{ github.ref_name != 'main' && 'untagged' || 'latest' }}


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use the latest Node.js version and GitHub Actions runner versions

CI:
- Upgrade GitHub Actions checkout and setup-node actions to their latest versions
- Update Node.js version from 18.x to 20 across all CI workflows