### PR TITLE
fix: handle invalid unicode in path parameter encoding

### DIFF
--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -38,7 +38,7 @@ import {
 } from '../utils/common';
 import {parseRestError} from '../utils/parse-error';
 import {redactSensitiveHeaders} from '../utils/redact-sensitive-headers';
-import {encodePathParams, getPathArgsProxy, validateArgs} from '../utils/validate';
+import {getPathArgsProxy, validateArgs} from '../utils/validate';
 
 function getRestResponseSize<Context extends GatewayContext>(
     data: unknown,
@@ -161,10 +161,11 @@ export default function createRestAction<Context extends GatewayContext>(
             ? endpointData.axiosConfig
             : undefined;
 
-        const pathArgs = config.validationSchema
-            ? encodePathParams(args)
-            : getPathArgsProxy(args, options.encodePathArgs);
-        const actionPath = typeof config.path === 'function' ? config.path(pathArgs) : config.path;
+        const actionPath =
+            typeof config.path === 'function'
+                ? config.path(getPathArgsProxy(args, options.encodePathArgs))
+                : config.path;
+
         const actionURL = actionEndpoint + actionPath;
         const parsedActionURL = url.parse(actionURL);
         const proxyHeaders = [...DEFAULT_PROXY_HEADERS];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -92,3 +92,5 @@ export const DEFAULT_VALIDATION_SCHEMA = {
 };
 
 export const AXIOS_RETRY_NAMESPACE = 'axios-retry';
+
+export const GATEWAY_INVALID_PARAM_VALUE = 'GATEWAY_INVALID_PARAM_VALUE';


### PR DESCRIPTION
- Replace encodePathParams with getPathArgsProxy
- Add try/catch for encodeURIComponent in getPathArgsProxy
- Add tests for URI encoding and invalid unicode
- Extract GATEWAY_INVALID_PARAM_VALUE constant

Fixes issue where encodeURIComponent would throw on invalid unicode surrogates like '\uDCE2', causing application crashes.