### PR TITLE
feat: fallback to lowercased header name

### DIFF
--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -295,7 +295,10 @@ function createMetadata<Context extends GatewayContext>({
 
     for (const headerName of proxyHeaders) {
         if (metadata[headerName] === undefined) {
-            metadata[headerName] = headers[headerName];
+            metadata[headerName] =
+                headers[headerName] !== undefined
+                    ? headers[headerName]
+                    : headers[headerName.toLowerCase()];
         }
     }
 

--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -204,7 +204,10 @@ export default function createRestAction<Context extends GatewayContext>(
 
         for (const headerName of proxyHeaders) {
             if (actionHeaders[headerName] === undefined) {
-                actionHeaders[headerName] = requestHeaders[headerName];
+                actionHeaders[headerName] =
+                    requestHeaders[headerName] !== undefined
+                        ? requestHeaders[headerName]
+                        : requestHeaders[headerName.toLowerCase()];
             }
         }
 


### PR DESCRIPTION
Resolves #147

## Summary by Sourcery

Bug Fixes:
- Support lowercased header names in header proxying for gRPC metadata and REST actions