### PR TITLE
fix: correct responseSize for stream responses (#170)

### DIFF
--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+import {Transform} from 'stream';
 import url from 'url';
 
 import type {AxiosRequestConfig} from 'axios';
@@ -429,16 +430,30 @@ export default function createRestAction<Context extends GatewayContext>(
             }
 
             if (options?.sendStats) {
-                options.sendStats(
-                    {
-                        ...requestData,
-                        responseSize: getRestResponseSize(response?.data, ctx, ErrorConstructor),
-                        restStatus: 200,
-                    } as Stats,
-                    redactSensitiveHeaders(parentCtx, headers),
-                    parentCtx,
-                    {debugHeaders: sanitizeDebugHeaders(debugHeaders)},
-                );
+                const emitStats = (responseSize: number, restStatus: number) =>
+                    options.sendStats?.(
+                        {...requestData, responseSize, restStatus} as Stats,
+                        redactSensitiveHeaders(parentCtx, headers),
+                        parentCtx,
+                        {debugHeaders: sanitizeDebugHeaders(debugHeaders)},
+                    );
+
+                if (response.data && typeof response.data.pipe === 'function') {
+                    let streamedBytes = 0;
+                    const counter = new Transform({
+                        transform(chunk, _enc, cb) {
+                            streamedBytes += chunk.length;
+                            cb(null, chunk);
+                        },
+                        flush(cb) {
+                            emitStats(streamedBytes, 200);
+                            cb();
+                        },
+                    });
+                    response.data = response.data.pipe(counter);
+                } else {
+                    emitStats(getRestResponseSize(response?.data, ctx, ErrorConstructor), 200);
+                }
             } else {
                 ctx.stats({
                     ...requestData,

--- a/lib/components/rest.ts
+++ b/lib/components/rest.ts
@@ -1,5 +1,4 @@
 import querystring from 'querystring';
-import {Transform} from 'stream';
 import url from 'url';
 
 import type {AxiosRequestConfig} from 'axios';
@@ -39,6 +38,7 @@ import {
     sanitizeDebugHeaders,
 } from '../utils/common';
 import {parseRestError} from '../utils/parse-error';
+import {pipeThroughByteCounter} from '../utils/pipe-through-byte-counter';
 import {redactSensitiveHeaders} from '../utils/redact-sensitive-headers';
 import {getPathArgsProxy, validateArgs} from '../utils/validate';
 
@@ -439,18 +439,9 @@ export default function createRestAction<Context extends GatewayContext>(
                     );
 
                 if (response.data && typeof response.data.pipe === 'function') {
-                    let streamedBytes = 0;
-                    const counter = new Transform({
-                        transform(chunk, _enc, cb) {
-                            streamedBytes += chunk.length;
-                            cb(null, chunk);
-                        },
-                        flush(cb) {
-                            emitStats(streamedBytes, 200);
-                            cb();
-                        },
-                    });
-                    response.data = response.data.pipe(counter);
+                    response.data = pipeThroughByteCounter(response.data, (streamedBytes) =>
+                        emitStats(streamedBytes, 200),
+                    );
                 } else {
                     emitStats(getRestResponseSize(response?.data, ctx, ErrorConstructor), 200);
                 }

--- a/lib/utils/pipe-through-byte-counter.test.ts
+++ b/lib/utils/pipe-through-byte-counter.test.ts
@@ -1,0 +1,78 @@
+import {Readable} from 'stream';
+import {finished} from 'stream/promises';
+
+import {pipeThroughByteCounter} from './pipe-through-byte-counter';
+
+async function drain(readable: Readable): Promise<void> {
+    readable.resume();
+    await finished(readable);
+}
+
+describe('pipeThroughByteCounter', () => {
+    test('calls onFlush with 0 for an empty source', async () => {
+        const onFlush = jest.fn();
+        const source = Readable.from([]);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        await drain(out);
+
+        expect(onFlush).toHaveBeenCalledTimes(1);
+        expect(onFlush).toHaveBeenCalledWith(0);
+    });
+
+    test('sums Buffer chunks as byte length', async () => {
+        const onFlush = jest.fn();
+        const source = Readable.from([Buffer.from('ab'), Buffer.from('cde')]);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        await drain(out);
+
+        expect(onFlush).toHaveBeenCalledTimes(1);
+        expect(onFlush).toHaveBeenCalledWith(5);
+    });
+
+    test('sums Uint8Array chunks', async () => {
+        const onFlush = jest.fn();
+        const source = Readable.from([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])]);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        await drain(out);
+
+        expect(onFlush).toHaveBeenCalledWith(5);
+    });
+
+    test('counts string chunks using Buffer.byteLength (utf8)', async () => {
+        const onFlush = jest.fn();
+        const source = Readable.from(['a', 'é']);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        await drain(out);
+
+        expect(onFlush).toHaveBeenCalledWith(Buffer.byteLength('a') + Buffer.byteLength('é'));
+    });
+
+    test('sums mixed Buffer and string chunks', async () => {
+        const onFlush = jest.fn();
+        const source = Readable.from([Buffer.from('zz'), 'π']);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        await drain(out);
+
+        expect(onFlush).toHaveBeenCalledWith(2 + Buffer.byteLength('π'));
+    });
+
+    test('forwards binary data unchanged', async () => {
+        const onFlush = jest.fn();
+        const a = Buffer.from([0, 255, 128]);
+        const source = Readable.from([a]);
+
+        const out = pipeThroughByteCounter(source, onFlush);
+        const chunks: Uint8Array[] = [];
+        out.on('data', (c) => chunks.push(c instanceof Uint8Array ? c : new Uint8Array(c)));
+
+        await finished(out);
+
+        expect(Buffer.concat(chunks)).toEqual(a);
+        expect(onFlush).toHaveBeenCalledWith(3);
+    });
+});

--- a/lib/utils/pipe-through-byte-counter.ts
+++ b/lib/utils/pipe-through-byte-counter.ts
@@ -1,0 +1,30 @@
+import {Transform} from 'stream';
+import type {Readable} from 'stream';
+
+export function pipeThroughByteCounter(
+    source: NodeJS.ReadableStream,
+    onFlush: (streamedBytes: number) => void,
+): Readable {
+    let streamedBytes = 0;
+
+    const counter = new Transform({
+        transform(chunk, encoding, cb) {
+            if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+                streamedBytes += chunk.length;
+            } else if (typeof chunk === 'string') {
+                streamedBytes += Buffer.byteLength(
+                    chunk,
+                    typeof encoding === 'string' ? encoding : undefined,
+                );
+            }
+
+            cb(null, chunk);
+        },
+        flush(cb) {
+            onFlush(streamedBytes);
+            cb();
+        },
+    });
+
+    return source.pipe(counter);
+}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix response size accounting for streamed REST responses by counting bytes as they are piped.