### PR TITLE
feat: add sendStats for mixed actions

### DIFF
--- a/lib/components/mixed.ts
+++ b/lib/components/mixed.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_LANG_HEADER, Lang} from '../constants';
+import {DEFAULT_LANG_HEADER, ECMA_STRING_SIZE, Lang} from '../constants';
 import {
     ApiActionConfig,
     ApiByScope,
@@ -7,14 +7,32 @@ import {
     GatewayRequest,
     GatewayResponse,
     SchemasByScope,
+    SendStats,
+    Stats,
 } from '../models/common';
 import {GatewayContext} from '../models/context';
 import {AppErrorConstructor} from '../models/error';
 import {handleError} from '../utils/common';
 import {generateContextApi} from '../utils/create-context-api';
 import {parseMixedError} from '../utils/parse-error';
+import {redactSensitiveHeaders} from '../utils/redact-sensitive-headers';
 
 import type {GrpcContext} from './grpc';
+
+function getMixedResponseSize<Context extends GatewayContext>(
+    data: unknown,
+    ctx: Context,
+    ErrorConstructor: AppErrorConstructor,
+) {
+    let responseSize = 0;
+    try {
+        responseSize = ECMA_STRING_SIZE * JSON.stringify(data)?.length;
+    } catch (error) {
+        handleError(ErrorConstructor, error, ctx, 'Calculate response size failed');
+    }
+
+    return responseSize;
+}
 
 export function createMixedAction<
     TSchema extends SchemasByScope,
@@ -26,11 +44,16 @@ export function createMixedAction<
     api: ApiByScope<TSchema, Context, Req, Res>,
     serviceName: string,
     actionName: string,
-    extra: {config: GatewayConfig<Context, Req, Res>; grpcContext: GrpcContext},
+    extra: {
+        config: GatewayConfig<Context, Req, Res>;
+        grpcContext: GrpcContext;
+        sendStats?: SendStats<Context>;
+    },
     ErrorConstructor: AppErrorConstructor,
 ) {
     return async (actionConfig: ApiActionConfig<Context, any>) => {
         const {args, ...context} = actionConfig;
+        const {requestId, headers: requestHeaders, ctx: parentCtx, userId} = actionConfig;
 
         const ctx = actionConfig.ctx.create(`Gateway ${serviceName} ${actionName} [mixed]`, {
             tags: {
@@ -40,6 +63,18 @@ export function createMixedAction<
             },
         });
         const contextApi = generateContextApi(api, {...context, ctx});
+
+        const startRequestTime = Date.now();
+        const requestData: Record<string, string | number> = {
+            timestamp: startRequestTime,
+            service: serviceName,
+            action: actionName,
+            requestId: requestId || '',
+            requestMethod: '',
+            requestUrl: '',
+            traceId: ctx.getTraceId?.() || '',
+            userId: userId || '',
+        };
 
         try {
             const responseData = await config(contextApi, args, {
@@ -52,11 +87,37 @@ export function createMixedAction<
 
             ctx.log('Request completed');
 
+            extra.sendStats?.(
+                {
+                    ...requestData,
+                    requestTime: Date.now() - startRequestTime,
+                    responseSize: getMixedResponseSize(responseData, ctx, ErrorConstructor),
+                    restStatus: 200,
+                } as Stats,
+                redactSensitiveHeaders(parentCtx, requestHeaders),
+                parentCtx,
+                {debugHeaders: {}},
+            );
+
             return {
                 responseData,
                 debugHeaders: {},
             };
         } catch (e) {
+            const errorData = e instanceof Object && 'error' in e ? e.error : e;
+            const restStatus = (errorData as any)?.status || 500;
+            extra.sendStats?.(
+                {
+                    ...requestData,
+                    requestTime: Date.now() - startRequestTime,
+                    responseSize: getMixedResponseSize(errorData, ctx, ErrorConstructor),
+                    restStatus,
+                } as Stats,
+                redactSensitiveHeaders(parentCtx, requestHeaders),
+                parentCtx,
+                {debugHeaders: {}},
+            );
+
             if (e instanceof Object && 'error' in e) {
                 handleError(ErrorConstructor, e, ctx, 'Request failed', {
                     actionName,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -88,7 +88,7 @@ function createApiAction<
             api,
             resultServiceName,
             actionName,
-            {config, grpcContext},
+            {config, grpcContext, sendStats: config.sendStats},
             config.ErrorConstructor,
         );
     }


### PR DESCRIPTION
Added `sendStats` for mixed actions

## Summary by Sourcery

Add optional request statistics collection to mixed actions and propagate configuration for sending stats from the API action factory.

New Features:
- Enable mixed actions to emit request statistics via an optional sendStats callback, including timing, response size, and status information.

Enhancements:
- Redact sensitive headers and compute response payload size when reporting statistics for mixed actions.