### PR TITLE
feat(grpc): retry before recreating grpc client

### DIFF
--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1175,9 +1175,10 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const shouldRetry =
                                     error &&
                                     retries &&
-                                    (options.grpcRetryCondition?.(error) ??
-                                        isRetryableGrpcError(error));
-                                if (shouldRecreateService) {
+                                    (shouldRecreateService ||
+                                        (options.grpcRetryCondition?.(error) ??
+                                            isRetryableGrpcError(error)));
+                                if (shouldRecreateService && !shouldRetry) {
                                     ctx.log(
                                         `Service client for ${config.protoKey} is going to be re-created`,
                                     );

--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1175,9 +1175,8 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const shouldRetry =
                                     error &&
                                     retries &&
-                                    (shouldRecreateService ||
-                                        (options.grpcRetryCondition?.(error) ??
-                                            isRetryableGrpcError(error)));
+                                    (options.grpcRetryCondition?.(error) ??
+                                        isRetryableGrpcError(error));
                                 if (shouldRecreateService && !shouldRetry) {
                                     ctx.log(
                                         `Service client for ${config.protoKey} is going to be re-created`,


### PR DESCRIPTION
With the current (in main branch) configuration, grpc client is recreated immediately when a timeout occurs without using retries.

In the PR I change flow to use provided retries then recreate service.

## Summary by Sourcery

Adjust gRPC client error handling to prefer configured retries before recreating the service client.

Enhancements:
- Update retry condition logic so timeouts that would trigger client recreation now participate in the standard gRPC retry flow.
- Prevent immediate gRPC service client recreation when a retry will be attempted, reducing unnecessary client rebuilds.