### PR TITLE
feat: retry before recreating grpc client

### DIFF
--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1175,9 +1175,10 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const shouldRetry =
                                     error &&
                                     retries &&
-                                    (options.grpcRetryCondition?.(error) ??
-                                        isRetryableGrpcError(error));
-                                if (shouldRecreateService) {
+                                    (shouldRecreateService ||
+                                        (options.grpcRetryCondition?.(error) ??
+                                            isRetryableGrpcError(error)));
+                                if (shouldRecreateService && !shouldRetry) {
                                     ctx.log(
                                         `Service client for ${config.protoKey} is going to be re-created`,
                                     );

--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1175,9 +1175,8 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const shouldRetry =
                                     error &&
                                     retries &&
-                                    (shouldRecreateService ||
-                                        (options.grpcRetryCondition?.(error) ??
-                                            isRetryableGrpcError(error)));
+                                    (options.grpcRetryCondition?.(error) ??
+                                        isRetryableGrpcError(error));
                                 if (shouldRecreateService && !shouldRetry) {
                                     ctx.log(
                                         `Service client for ${config.protoKey} is going to be re-created`,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -63,6 +63,7 @@ export const RETRYABLE_STATUS_CODES: Array<grpc.status | undefined> = [
     grpc.status.CANCELLED,
     grpc.status.ABORTED,
     grpc.status.UNKNOWN,
+    grpc.status.DEADLINE_EXCEEDED,
 ];
 
 export const RECREATE_SERVICE_CODES: Array<grpc.status | undefined> = [


### PR DESCRIPTION
## Summary by Sourcery

Adjust gRPC retry behavior to prefer retrying over client recreation for retryable errors and expand the set of retryable gRPC status codes.

Bug Fixes:
- Prevent unnecessary gRPC client recreation when a request should instead be retried for retryable errors.

Enhancements:
- Treat DEADLINE_EXCEEDED as a retryable gRPC status code to align retry logic with expected transient error handling.