### PR TITLE
fix: fix connectivity state log condition

### DIFF
--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1049,7 +1049,7 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                     isRecreateServiceError(error);
                                 const shouldRetry = error && retries && isRetryableError(error);
 
-                                if (shouldRecreateService || shouldRetry) {
+                                if (error) {
                                     const connectivityState = service
                                         .getChannel()
                                         .getConnectivityState(false);


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Log the gRPC channel connectivity state for any encountered error, rather than only retryable or service-recreation errors.