### PR TITLE
fix(grpc): recreate stuck clients before retries and fix reflection client recreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ const customGrpcRetryCondition = (error) => {
 };
 ```
 
-For gRPC-requests that fail with `DEADLINE_EXCEEDED`, the service connection is recreated before retrying if config option `grpcRecreateService` is not set to `false`.
+For gRPC-requests that fail with `DEADLINE_EXCEEDED`, the service connection is recreated if config option `grpcRecreateService` is not set to `false`. If the channel is in a broken state (`CONNECTING`, `TRANSIENT_FAILURE` or `SHUTDOWN`), the connection is recreated before retrying, so retries don't reuse a stuck channel. If the channel is `READY` (the deadline was most likely caused by a slow backend), the connection is recreated only after all retries are exhausted.
 
 ### Request Cancellation
 

--- a/README.md
+++ b/README.md
@@ -631,7 +631,10 @@ const customGrpcRetryCondition = (error) => {
 };
 ```
 
-For gRPC-requests that fail with `DEADLINE_EXCEEDED`, the service connection is recreated if config option `grpcRecreateService` is not set to `false`. If the channel is in a broken state (`CONNECTING`, `TRANSIENT_FAILURE` or `SHUTDOWN`), the connection is recreated before retrying, so retries don't reuse a stuck channel. If the channel is `READY` (the deadline was most likely caused by a slow backend), the connection is recreated only after all retries are exhausted.
+Unless config option `grpcRecreateService` is set to `false`, the service connection is recreated when it is likely broken:
+
+- the request failed with a connectivity error (`UNAVAILABLE`, `CANCELLED`, `ABORTED`, `UNKNOWN` or `DEADLINE_EXCEEDED`) while the channel is in a broken state (`CONNECTING`, `TRANSIENT_FAILURE` or `SHUTDOWN`) — the connection is recreated before retrying, so retries don't reuse a stuck channel;
+- the request failed with `DEADLINE_EXCEEDED` while the channel is `READY` (the deadline was most likely caused by a slow backend) — the connection is recreated only after all retries are exhausted.
 
 ### Request Cancellation
 

--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -1262,10 +1262,11 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                     retries &&
                                     (options.grpcRetryCondition?.(error) ??
                                         isRetryableGrpcError(error));
-                                // Retrying on a channel stuck in CONNECTING/TRANSIENT_FAILURE/
-                                // SHUTDOWN is pointless, so re-create the client before such a
-                                // retry. When the channel is READY, the deadline most likely
-                                // comes from a slow backend and the client is re-created only
+                                // A connectivity error on a channel stuck in CONNECTING/
+                                // TRANSIENT_FAILURE/SHUTDOWN means the client itself is
+                                // likely broken - re-create it (before the retry, if any).
+                                // When the channel is READY, a deadline most likely comes
+                                // from a slow backend, so the client is re-created only
                                 // after retries are exhausted
                                 const isChannelBroken =
                                     connectivityState !== undefined &&
@@ -1274,8 +1275,8 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const shouldRecreateService =
                                     error &&
                                     options.grpcRecreateService &&
-                                    isRecreateServiceError(error) &&
-                                    (isChannelBroken || !shouldRetry);
+                                    ((isChannelBroken && isConnectivityGrpcError(error)) ||
+                                        (isRecreateServiceError(error) && !shouldRetry));
 
                                 if (shouldRecreateService) {
                                     ctx.log(

--- a/lib/components/grpc.ts
+++ b/lib/components/grpc.ts
@@ -58,11 +58,16 @@ import {
 } from '../utils/common';
 import {
     decodeAnyMessageRecursively,
+    isConnectivityGrpcError,
     isRecreateServiceError,
     isRetryableGrpcError,
     listenForAbort,
 } from '../utils/grpc';
-import {getCachedReflectionRoot, getReflectionRoot} from '../utils/grpc-reflection';
+import {
+    clearReflectionClientCache,
+    getCachedReflectionRoot,
+    getReflectionRoot,
+} from '../utils/grpc-reflection';
 import {GrpcError, grpcErrorFactory, isGrpcError, parseGrpcError} from '../utils/parse-error';
 import {patchProtoPathResolver} from '../utils/proto-path-resolver';
 import {redactSensitiveHeaders} from '../utils/redact-sensitive-headers';
@@ -349,37 +354,88 @@ const packageObjectsMap: Map<protobufjs.Root, Record<string, grpc.GrpcObject>> =
 const serviceInstancesMap: Record<string, Record<string, ServiceClient>> = {};
 const reflectionServiceInstancesMap: Record<string, Record<string, Promise<ServiceClient>>> = {};
 
+// Grace period added to the request deadline before closing a replaced client,
+// so in-flight calls from other requests are not killed by close()
+const CLIENT_CLOSE_GRACE_MS = 5000;
+
+const serviceCachePromiseSymbol = Symbol('serviceCachePromise');
+
+type ServiceClientWithCacheRef = ServiceClient & {
+    [serviceCachePromiseSymbol]?: Promise<ServiceClient>;
+};
+
+/**
+ * Stamps the resolved client with the promise it was cached under, so
+ * `clearInstancesCache` can match a client against the cached promise
+ * synchronously. Awaiting the cache entry there instead is not an option: the
+ * entry may be a pending promise (e.g. a hanging reflection request) and the
+ * await would never settle.
+ */
+function markCachedServicePromise(promise: Promise<ServiceClient>) {
+    promise
+        .then((client) => {
+            (client as ServiceClientWithCacheRef)[serviceCachePromiseSymbol] = promise;
+        })
+        .catch(() => {});
+    return promise;
+}
+
+function closeServiceClient(
+    client: ServiceClient | undefined,
+    closeTimeout: number,
+    onCloseError?: (error: unknown) => void,
+) {
+    // Try to close service connection (prevent memory leak)
+    // Bug in node >= 18.15.0 https://github.com/grpc/grpc-node/issues/2091
+    // use setTimeout
+    const timer = setTimeout(() => {
+        try {
+            client?.close?.();
+        } catch (error) {
+            onCloseError?.(error);
+        }
+    }, closeTimeout);
+
+    timer.unref?.();
+}
+
+/**
+ * Removes the failed service client from the cache and schedules closing its
+ * connection. Returns `true` if the client was actually removed, `false` if
+ * the cache already holds another client (e.g. a concurrent request has
+ * re-created it earlier).
+ */
 function clearInstancesCache<Context extends GatewayContext>(
     service: ServiceClient,
     instancesMap: typeof serviceInstancesMap | typeof reflectionServiceInstancesMap,
     cachePath: [string, string],
     closeTimeout: number,
     ctx: Context,
-) {
+): boolean {
     const cachedService = _.get(instancesMap, cachePath);
 
-    if (cachedService !== service) {
+    // The reflection cache stores promises: compare with the promise the
+    // client was stamped with on creation (see markCachedServicePromise)
+    const cachePromiseRef = (service as ServiceClientWithCacheRef)[serviceCachePromiseSymbol];
+    const isCachedService =
+        cachedService !== undefined &&
+        (cachedService === service || cachedService === cachePromiseRef);
+
+    if (!isCachedService) {
         ctx.log(`Service client not matched cached service for cachePath '${cachePath}'`);
-        return;
+        return false;
     }
 
     // Remove cached service instance
     _.unset(instancesMap, cachePath);
 
-    // Try to close service connection (prevent memory leak)
-    // Bug in node >= 18.15.0 https://github.com/grpc/grpc-node/issues/2091
-    // use setTimeout
-    Promise.resolve(cachedService).then((client) => {
-        setTimeout(() => {
-            try {
-                client?.close?.();
-            } catch (error) {
-                ctx.logError('Failed to close connection during clearing instances cache', error, {
-                    cachePath,
-                });
-            }
-        }, closeTimeout);
+    closeServiceClient(service, closeTimeout, (error) => {
+        ctx.logError('Failed to close connection during clearing instances cache', error, {
+            cachePath,
+        });
     });
+
+    return true;
 }
 
 function getChannelCredential(
@@ -489,15 +545,30 @@ async function refreshCache(
             credentials,
             true,
         );
+        const previousServiceInstance = _.get(reflectionServiceInstancesMap, [
+            config.protoKey,
+            actionEndpoint,
+        ]);
         _.set(
             reflectionServiceInstancesMap,
             [config.protoKey, actionEndpoint],
-            Promise.resolve(res),
+            markCachedServicePromise(Promise.resolve(res)),
         );
         _.set(reflectionCacheStatusMap, [config.protoKey, actionEndpoint], {
             time: Date.now() / 1000,
             isRefresh: false,
         });
+
+        // Close the replaced client, otherwise its connection leaks
+        if (previousServiceInstance) {
+            Promise.resolve(previousServiceInstance)
+                .then((client) => {
+                    if (client !== res) {
+                        closeServiceClient(client, DEFAULT_TIMEOUT + CLIENT_CLOSE_GRACE_MS);
+                    }
+                })
+                .catch(() => {});
+        }
     } catch (e) {
         _.set(reflectionCacheStatusMap, [config.protoKey, actionEndpoint], {
             ...cacheStatus,
@@ -531,7 +602,9 @@ function getServiceInstanceReflectCached(
         return cachedServiceInstance;
     }
 
-    const service = getServiceInstanceReflect(config, endpointData, grpcOptions, credentials);
+    const service = markCachedServicePromise(
+        getServiceInstanceReflect(config, endpointData, grpcOptions, credentials),
+    );
     _.set(reflectionServiceInstancesMap, cacheKey, service);
     service.catch(() => {
         _.set(reflectionServiceInstancesMap, cacheKey, undefined);
@@ -745,6 +818,26 @@ export default function createGrpcAction<Context extends GatewayContext>(
     let getActionEndpoint: (args: unknown) => string;
     const grpcOptions = options?.grpcOptions || {};
 
+    const clearServiceCache = (
+        service: ServiceClient,
+        actionEndpoint: string,
+        closeTimeout: number,
+        ctx: Context,
+    ) => {
+        const isReflection = 'reflection' in config;
+        const instancesMap = isReflection ? reflectionServiceInstancesMap : serviceInstancesMap;
+        const cachePath = [config.protoKey, actionEndpoint] as [string, string];
+
+        const cleared = clearInstancesCache(service, instancesMap, cachePath, closeTimeout, ctx);
+
+        // The reflection client channel points to the same endpoint and may be
+        // stuck in the same broken state, so re-create it together with the
+        // service client
+        if (cleared && isReflection) {
+            clearReflectionClientCache(actionEndpoint);
+        }
+    };
+
     if (!('reflection' in config)) {
         loadAndCachePackageObject(root, config.protoPath);
     }
@@ -766,13 +859,8 @@ export default function createGrpcAction<Context extends GatewayContext>(
             // Client will be created on first request because it depends on args
             return getServiceInstance(root, config, endpointData, grpcOptions, credentials);
         };
-        recreateService = (service, closeTimeout, ctx, args) => {
-            const actionEndpoint = getActionEndpoint(args);
-            const serviceInstancesCache =
-                'reflection' in config ? reflectionServiceInstancesMap : serviceInstancesMap;
-            const cachePath = [config.protoKey, actionEndpoint] as [string, string];
-            clearInstancesCache(service, serviceInstancesCache, cachePath, closeTimeout, ctx);
-        };
+        recreateService = (service, closeTimeout, ctx, args) =>
+            clearServiceCache(service, getActionEndpoint(args), closeTimeout, ctx);
     } else if (endpoints) {
         let endpointData = endpoints.grpcEndpoint || endpoints.endpoint;
 
@@ -790,35 +878,13 @@ export default function createGrpcAction<Context extends GatewayContext>(
             ) {
                 getService = () =>
                     getServiceInstanceReflectCached(config, endpointData, grpcOptions, credentials);
-                recreateService = (service, closeTimeout, ctx) => {
-                    const cachePath = [config.protoKey, actionEndpoint] as [string, string];
-                    clearInstancesCache(
-                        service,
-                        reflectionServiceInstancesMap,
-                        cachePath,
-                        closeTimeout,
-                        ctx,
-                    );
-                };
             } else {
                 getService = () =>
                     getServiceInstance(root, config, endpointData, grpcOptions, credentials);
-                recreateService = (service, closeTimeout, ctx) => {
-                    const serviceInstancesCache =
-                        'reflection' in config
-                            ? reflectionServiceInstancesMap
-                            : serviceInstancesMap;
-                    const cachePath = [config.protoKey, actionEndpoint] as [string, string];
-                    clearInstancesCache(
-                        service,
-                        serviceInstancesCache,
-                        cachePath,
-                        closeTimeout,
-                        ctx,
-                    );
-                };
             }
 
+            recreateService = (service, closeTimeout, ctx) =>
+                clearServiceCache(service, actionEndpoint, closeTimeout, ctx);
             getActionEndpoint = () => actionEndpoint;
         }
     }
@@ -938,6 +1004,17 @@ export default function createGrpcAction<Context extends GatewayContext>(
             service = await getService(args);
         } catch (error) {
             handleError(ErrorConstructor, error, ctx, 'getService failed');
+            // The reflection client may be the cause of a connectivity failure
+            // (e.g. its channel is stuck), drop it so the next request creates
+            // a fresh one. On deterministic errors (unknown protoKey, decoding)
+            // clearing would only disturb healthy services on the endpoint
+            if ('reflection' in config && isConnectivityGrpcError(error as grpc.ServiceError)) {
+                try {
+                    clearReflectionClientCache(getActionEndpoint(args));
+                } catch {
+                    // getActionEndpoint may throw for a custom endpoint function
+                }
+            }
             throw error;
         }
 
@@ -1169,18 +1246,9 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                 const endRequestTime = Date.now();
                                 requestData.requestTime = endRequestTime - startRequestTime;
 
-                                const shouldRecreateService =
-                                    error &&
-                                    options.grpcRecreateService &&
-                                    isRecreateServiceError(error);
-                                const shouldRetry =
-                                    error &&
-                                    retries &&
-                                    (options.grpcRetryCondition?.(error) ??
-                                        isRetryableGrpcError(error));
-
+                                let connectivityState: ConnectivityState | undefined;
                                 if (error) {
-                                    const connectivityState = service
+                                    connectivityState = service
                                         .getChannel()
                                         .getConnectivityState(false);
 
@@ -1189,11 +1257,38 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                     );
                                 }
 
-                                if (shouldRecreateService && !shouldRetry) {
+                                const shouldRetry =
+                                    error &&
+                                    retries &&
+                                    (options.grpcRetryCondition?.(error) ??
+                                        isRetryableGrpcError(error));
+                                // Retrying on a channel stuck in CONNECTING/TRANSIENT_FAILURE/
+                                // SHUTDOWN is pointless, so re-create the client before such a
+                                // retry. When the channel is READY, the deadline most likely
+                                // comes from a slow backend and the client is re-created only
+                                // after retries are exhausted
+                                const isChannelBroken =
+                                    connectivityState !== undefined &&
+                                    connectivityState !== ConnectivityState.READY &&
+                                    connectivityState !== ConnectivityState.IDLE;
+                                const shouldRecreateService =
+                                    error &&
+                                    options.grpcRecreateService &&
+                                    isRecreateServiceError(error) &&
+                                    (isChannelBroken || !shouldRetry);
+
+                                if (shouldRecreateService) {
                                     ctx.log(
                                         `Service client for ${config.protoKey} is going to be re-created`,
                                     );
-                                    recreateService(service, 5000, ctx, args);
+                                    // Clearing is synchronous, so the retry below can't pick
+                                    // up the stale client from the cache
+                                    recreateService(
+                                        service,
+                                        timeout + CLIENT_CLOSE_GRACE_MS,
+                                        ctx,
+                                        args,
+                                    );
                                 }
 
                                 if (shouldRetry) {
@@ -1211,14 +1306,27 @@ export default function createGrpcAction<Context extends GatewayContext>(
                                     // Update pointer to re-created client in local service variable
                                     try {
                                         service = await getService(args);
-                                    } catch (error) {
+                                    } catch (getServiceError) {
                                         handleError(
                                             ErrorConstructor,
-                                            error,
+                                            getServiceError,
                                             ctx,
                                             'getService failed',
                                         );
-                                        throw error;
+                                        if (
+                                            'reflection' in config &&
+                                            isConnectivityGrpcError(
+                                                getServiceError as grpc.ServiceError,
+                                            )
+                                        ) {
+                                            clearReflectionClientCache(actionEndpoint);
+                                        }
+                                        stopListeningForAbort?.();
+                                        // Reject instead of throwing: nothing awaits this
+                                        // callback, so a thrown error would leave the request
+                                        // promise pending forever
+                                        reject(getServiceError);
+                                        return;
                                     }
 
                                     stopListeningForAbort?.();

--- a/lib/utils/grpc-reflection.ts
+++ b/lib/utils/grpc-reflection.ts
@@ -58,6 +58,30 @@ function getCachedClient(
 }
 
 /**
+ * Drops cached reflection clients for the endpoint and closes their
+ * connections. Used when the service client for the endpoint is re-created:
+ * the reflection client channel points to the same endpoint and may be
+ * stuck in the same broken state.
+ */
+export function clearReflectionClientCache(actionEndpoint: string) {
+    const clientsByOptions = reflectionClientsMap[actionEndpoint];
+
+    if (!clientsByOptions) {
+        return;
+    }
+
+    delete reflectionClientsMap[actionEndpoint];
+
+    Object.values(clientsByOptions).forEach(({client}) => {
+        try {
+            (client.grpcClient as unknown as {close?: () => void})?.close?.();
+        } catch {
+            // Best effort: the channel may already be closed
+        }
+    });
+}
+
+/**
  * @param actionEndpoint
  * @param protoKey
  * @param credentials

--- a/lib/utils/grpc.ts
+++ b/lib/utils/grpc.ts
@@ -98,6 +98,15 @@ export function isRecreateServiceError(error?: grpc.ServiceError) {
     return RECREATE_SERVICE_CODES.includes(error.code);
 }
 
+/**
+ * Whether the error looks like a connectivity problem rather than a
+ * deterministic one (unknown symbol, descriptor decoding, config errors).
+ * Deterministic errors are rejected without a grpc status code.
+ */
+export function isConnectivityGrpcError(error?: grpc.ServiceError) {
+    return isRetryableGrpcError(error) || isRecreateServiceError(error);
+}
+
 export type ListenForAbortArgs = {
     signal?: AbortSignal;
     config: {abortOnClientDisconnect?: boolean};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.15.1",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "1.12.6",
+        "@grpc/grpc-js": "1.14.4",
         "@grpc/proto-loader": "^0.7.8",
         "ajv": "^8.12.0",
         "axios": "^1.8.3",
@@ -1248,15 +1248,34 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
-      "integrity": "sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
         "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -10056,12 +10075,25 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
-      "integrity": "sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+          "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+          "requires": {
+            "lodash.camelcase": "^4.3.0",
+            "long": "^5.0.0",
+            "protobufjs": "^7.5.5",
+            "yargs": "^17.7.2"
+          }
+        }
       }
     },
     "@grpc/proto-loader": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test-integration-no-server": "jest --colors --config=jest.config-integration.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.12.6",
+    "@grpc/grpc-js": "1.14.4",
     "@grpc/proto-loader": "^0.7.8",
     "ajv": "^8.12.0",
     "axios": "^1.8.3",


### PR DESCRIPTION
## Summary by Sourcery

Ensure gRPC retries use fresh clients when channels are stuck and keep reflection-client caches synchronized.

Bug Fixes:
- Recreate stuck gRPC service clients before retrying connectivity failures and refresh reflection clients when their channels become unhealthy.
- Prevent failed client recreation from leaving requests unresolved and close replaced clients to avoid connection leaks.

Enhancements:
- Coordinate service and reflection-client cache invalidation while avoiding removal of clients replaced concurrently.
- Document the updated channel-state-dependent client recreation and retry behavior.

Build:
- Upgrade the @grpc/grpc-js dependency to 1.14.4.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves all 2 issues in [@grpc/grpc-js](https://app.sourcery.ai/dashboard/security/issues?groupId=68153659&issueIds=72446285,72446287)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->